### PR TITLE
fix: add nix queries + refactor: use macro for default_generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+tags

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate clap;
 
+use clap::Shell;
 use std::env;
 use std::path::PathBuf;
-use clap::Shell;
 
 include!("src/cli.rs");
 

--- a/nix/tags.scm
+++ b/nix/tags.scm
@@ -1,48 +1,9 @@
-; ADT definitions
-(adt
-    name: (type) @name) @definition.class
+; Functions
+(binding 
+  attrpath: (attrpath attr: (identifier))
+  expression: (function_expression)) @definition.function
 
-; Type family definitions
-(type_family
-    (_
-        name: (type) @name)) @definition.class
-
-; ADT constructor definitions
-(constructors
-    (data_constructor
-      (constructor) @name) @definition.function)
-
-(constructors
-    (data_constructor_record
-      (constructor) @name) @definition.function)
-
-; GADT constructor definitions
-
-(adt
-    (gadt_constructor
-      (constructor) @name) @definition.function)
-
-; Record field definitions
-(record_fields
-    (field
-      (variable) @name) @definition.function)
-
-; Type alias definitions
-(type_alias
-    name: (type) @name) @definition.class
-
-; Function definitions
-(function
-    name: (variable) @name) @definition.function
-
-(signature
-    name: (variable) @name) @definition.function
-
-; Class definitions
-(class
-    (_
-      class: (class_name) @name)) @definition.interface
-
-; Module definitions
-(_
-    module: (module) @name) @definition.module
+; Attrset bindings
+(binding
+  attrpath: (attrpath attr: (identifier))
+  expression: (apply_expression)) @definition.class

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -3,8 +3,8 @@
 macro_rules! default_generate_tags {
     () => {
         pub fn generate_tags<'a>(
-            context: &'a mut TagsContext,
-            config: &'a TagsConfiguration,
+            context: &'a mut npezza93_tree_sitter_tags::TagsContext,
+            config: &'a npezza93_tree_sitter_tags::TagsConfiguration,
             filename: &'a str,
             contents: &'a [u8],
         ) -> Vec<Tag> {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,26 +1,24 @@
+#[macro_export]
 // Default logic for generating tags
+macro_rules! default_generate_tags {
+    () => {
+        pub fn generate_tags<'a>(
+            context: &'a mut TagsContext,
+            config: &'a TagsConfiguration,
+            filename: &'a str,
+            contents: &'a [u8],
+        ) -> Vec<Tag> {
+            let tags = context.generate_tags(config, contents, None).unwrap().0;
 
-use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration, TagsContext};
-use std::str;
+            tags.flat_map(|tag| {
+                let tag = tag.unwrap();
+                let node_name = config.syntax_type_name(tag.syntax_type_id);
+                let tag_name = &contents[tag.name_range.start..tag.name_range.end];
+                let original_name = str::from_utf8(<&[u8]>::clone(&tag_name)).unwrap_or("");
 
-use crate::tag::Tag;
-
-pub fn default_generate_tags<'a>(
-    create_tag: fn(&str, &str, &TSTag, &str) -> Tag,
-    context: &'a mut TagsContext,
-    config: &'a TagsConfiguration,
-    filename: &'a str,
-    contents: &'a [u8],
-) -> Vec<Tag> {
-    let tags = context.generate_tags(config, contents, None).unwrap().0;
-
-    tags.flat_map(|tag| {
-        let tag = tag.unwrap();
-        let node_name = config.syntax_type_name(tag.syntax_type_id);
-        let tag_name = &contents[tag.name_range.start..tag.name_range.end];
-        let original_name = str::from_utf8(<&[u8]>::clone(&tag_name)).unwrap_or("");
-
-        vec![create_tag(original_name, node_name, &tag, filename)]
-    })
-    .collect::<Vec<Tag>>()
+                vec![create_tag(original_name, node_name, &tag, filename)]
+            })
+            .collect::<Vec<Tag>>()
+            }
+    }
 }

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -19,6 +19,6 @@ macro_rules! default_generate_tags {
                 vec![create_tag(original_name, node_name, &tag, filename)]
             })
             .collect::<Vec<Tag>>()
-            }
-    }
+        }
+    };
 }

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -1,7 +1,7 @@
 use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration, TagsContext};
 use std::str;
 
-use crate::generate;
+use crate::default_generate_tags;
 use crate::tag::Tag;
 
 pub fn config() -> TagsConfiguration {
@@ -13,14 +13,7 @@ pub fn config() -> TagsConfiguration {
     .unwrap()
 }
 
-pub fn generate_tags<'a>(
-    context: &'a mut TagsContext,
-    config: &'a TagsConfiguration,
-    filename: &'a str,
-    contents: &'a [u8],
-) -> Vec<Tag> {
-    generate::default_generate_tags(create_tag, context, config, filename, contents)
-}
+default_generate_tags!();
 
 fn create_tag<'a>(name: &'a str, node_name: &'a str, tag: &'a TSTag, filename: &'a str) -> Tag {
     let row = tag.span.start.row;

--- a/src/haskell.rs
+++ b/src/haskell.rs
@@ -1,4 +1,4 @@
-use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration, TagsContext};
+use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration};
 use std::str;
 
 use crate::default_generate_tags;

--- a/src/javascript.rs
+++ b/src/javascript.rs
@@ -1,7 +1,7 @@
 use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration, TagsContext};
 use std::str;
 
-use crate::generate;
+use crate::default_generate_tags;
 use crate::tag::Tag;
 
 pub fn config() -> TagsConfiguration {
@@ -13,14 +13,7 @@ pub fn config() -> TagsConfiguration {
     .unwrap()
 }
 
-pub fn generate_tags<'a>(
-    context: &'a mut TagsContext,
-    config: &'a TagsConfiguration,
-    filename: &'a str,
-    contents: &'a [u8],
-) -> Vec<Tag> {
-    generate::default_generate_tags(create_tag, context, config, filename, contents)
-}
+default_generate_tags!();
 
 fn create_tag<'a>(name: &'a str, node_name: &'a str, tag: &'a TSTag, filename: &'a str) -> Tag {
     let row = tag.span.start.row;

--- a/src/javascript.rs
+++ b/src/javascript.rs
@@ -1,4 +1,4 @@
-use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration, TagsContext};
+use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration};
 use std::str;
 
 use crate::default_generate_tags;

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,7 +1,7 @@
 use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration, TagsContext};
 use std::str;
 
-use crate::generate;
+use crate::default_generate_tags;
 use crate::tag::Tag;
 
 pub fn config() -> TagsConfiguration {
@@ -13,14 +13,7 @@ pub fn config() -> TagsConfiguration {
     .unwrap()
 }
 
-pub fn generate_tags<'a>(
-    context: &'a mut TagsContext,
-    config: &'a TagsConfiguration,
-    filename: &'a str,
-    contents: &'a [u8],
-) -> Vec<Tag> {
-    generate::default_generate_tags(create_tag, context, config, filename, contents)
-}
+default_generate_tags!();
 
 fn create_tag<'a>(name: &'a str, node_name: &'a str, tag: &'a TSTag, filename: &'a str) -> Tag {
     let row = tag.span.start.row;

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,4 +1,4 @@
-use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration, TagsContext};
+use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration};
 use std::str;
 
 use crate::default_generate_tags;

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1,7 +1,7 @@
 use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration, TagsContext};
 use std::str;
 
-use crate::generate;
+use crate::default_generate_tags;
 use crate::tag::Tag;
 
 pub fn config() -> TagsConfiguration {
@@ -13,14 +13,7 @@ pub fn config() -> TagsConfiguration {
     .unwrap()
 }
 
-pub fn generate_tags<'a>(
-    context: &'a mut TagsContext,
-    config: &'a TagsConfiguration,
-    filename: &'a str,
-    contents: &'a [u8],
-) -> Vec<Tag> {
-    generate::default_generate_tags(create_tag, context, config, filename, contents)
-}
+default_generate_tags!();
 
 fn create_tag<'a>(name: &'a str, node_name: &'a str, tag: &'a TSTag, filename: &'a str) -> Tag {
     let row = tag.span.start.row;

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1,4 +1,4 @@
-use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration, TagsContext};
+use npezza93_tree_sitter_tags::{Tag as TSTag, TagsConfiguration};
 use std::str;
 
 use crate::default_generate_tags;


### PR DESCRIPTION
Hey @npezza93 :wave: 

I was just refactoring #12 to use a macro (less boilerplate) and I noticed that somehow the Nix queries never got added (the ones that got merged are for Haskell, which will cause the app to panic).

This should fix that.